### PR TITLE
fix(searchbar): hide empty suggestions dropdown when no query or history (desktop & mobile)

### DIFF
--- a/src/features/search/DesktopSearchBar.tsx
+++ b/src/features/search/DesktopSearchBar.tsx
@@ -250,7 +250,7 @@ export function DesktopSearchBar() {
           strokeWidth={0.1}
         />
       </button>
-      {showSuggestions && renderSuggestions()}
+      {showSuggestions && (query || searchHistory.length > 0) && renderSuggestions()}
     </form>
   );
 }

--- a/src/features/search/MobileSearchBar.tsx
+++ b/src/features/search/MobileSearchBar.tsx
@@ -219,15 +219,17 @@ export function MobileSearchBar({ onSearch }: { onSearch?: (query: string) => vo
             </button>
           )}
         </form>
-        <div
-          role="listbox"
-          className="w-full bg-white z-[1001] animate-fade-in border-t border-[#e6e6e6] min-h-0 max-h-[calc(100vh-48px)] overflow-y-auto"
-          style={{ transition: 'opacity 0.2s cubic-bezier(.4,0,.2,1)' }}
-          aria-live="polite"
-          aria-busy={loadingSuggestions}
-        >
-          {getDropdownContent()}
-        </div>
+        {(query || searchHistory.length > 0) && showSuggestions && (
+          <div
+            role="listbox"
+            className="w-full bg-white z-[1001] animate-fade-in border-t border-[#e6e6e6] min-h-0 max-h-[calc(100vh-48px)] overflow-y-auto"
+            style={{ transition: 'opacity 0.2s cubic-bezier(.4,0,.2,1)' }}
+            aria-live="polite"
+            aria-busy={loadingSuggestions}
+          >
+            {getDropdownContent()}
+          </div>
+        )}
         <style>{`
           @keyframes fade-in {
             from { opacity: 0; transform: translateY(-8px); }


### PR DESCRIPTION
Se corrije pequeño bug que muestra un div vacío cuando el usuario ingresa a la app y utiliza el buscador por primera vez.